### PR TITLE
fix(bootstrap): Sync with latest updates from Bootstrap 3.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6.0",
         "drupal/core": "8.*",
-        "drupal/bootstrap": "3.12"
+        "drupal/bootstrap": "3.16"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/js/drupal.wxt_bootstrap.js
+++ b/js/drupal.wxt_bootstrap.js
@@ -21,6 +21,6 @@
    * @return {string}
    *   The version of WxT being used.
    */
-  Drupal.wxt_bootstrap.version = 'WxT v4.0.27';
+  Drupal.wxt_bootstrap.version = 'WxT v4.0.29';
 
 })(window.jQuery, window.Drupal, window.drupalSettings);

--- a/starterkits/wxt/README.md
+++ b/starterkits/wxt/README.md
@@ -26,4 +26,4 @@ Please refer to the @link registry Theme Registry @endlink topic.
 
 [Drupal Bootstrap]: https://www.drupal.org/project/bootstrap
 [WxT Bootstrap]: https://www.drupal.org/project/wxt_bootstrap
-[Bootstrap Framework]: https://getbootstrap.com/docs/3.3/
+[Bootstrap Framework]: https://getbootstrap.com/docs/3.4/

--- a/templates/system/pager.html.twig
+++ b/templates/system/pager.html.twig
@@ -39,7 +39,7 @@
       {# Print first item if we are not on the first page. #}
       {% if items.first %}
         <li class="pager__item pager__item--first">
-          <a href="{{ items.first.href }}" title="{{ 'Go to first page'|t }}" rel="prev"{{ items.first.attributes }}>
+          <a href="{{ items.first.href }}" title="{{ 'Go to first page'|t }}" rel="first"{{ items.first.attributes }}>
             <span class="visually-hidden">{{ 'First page'|t }}</span>
             <span aria-hidden="true">{{ items.first.text|default('first'|t) }}</span>
           </a>

--- a/templates/system/status-messages.html.twig
+++ b/templates/system/status-messages.html.twig
@@ -44,28 +44,40 @@
     'info': 'info',
   }
 %}
-{% for type, messages in message_list %}
-  {%
-    set message_classes = [
-      'alert',
-      'alert-' ~ status_classes[type],
-      'alert-dismissible',
-    ]
-  %}
-  {# Reset the attribute classes and then add the message specific classes. #}
-  <div{{ attributes.setAttribute('class', classes).addClass(message_classes, 'mrgn-tp-md', 'mrgn-bttm-md').setAttribute('role', 'alert') }} tabindex="0">
-    <button role="button" class="close" data-dismiss="alert" aria-label="{{ 'Close'|t }}"><span aria-hidden="true">&times;</span></button>
-    {% if status_headings[type] %}
-      <h4 class="sr-only">{{ status_headings[type] }}</h4>
-    {% endif %}
-    {% if messages|length > 1 %}
-      <ul class="item-list item-list--messages">
-        {% for message in messages %}
-          <li class="item item--message">{{ message }}</li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      {{ messages|first }}
-    {% endif %}
+{%
+  set status_roles = {
+    'status': 'status',
+    'error': 'alert',
+    'warning': 'alert',
+    'info': 'status',
+  }
+%}
+<div data-drupal-messages>
+  <div class="messages__wrapper">
+  {% for type, messages in message_list %}
+    {%
+      set message_classes = [
+        'alert',
+        'alert-' ~ status_classes[type],
+        'alert-dismissible',
+      ]
+    %}
+    {# Reset the attribute classes and then add the message specific classes. #}
+    <div{{ attributes.setAttribute('class', classes).addClass(message_classes, 'mrgn-tp-md', 'mrgn-bttm-md').setAttribute('role', status_roles[type]).setAttribute('aria-label', status_headings[type]) }} tabindex="0">
+      <button type="button" role="button" class="close" data-dismiss="alert" aria-label="{{ 'Close'|t }}"><span aria-hidden="true">&times;</span></button>
+      {% if status_headings[type] %}
+        <h2 class="sr-only">{{ status_headings[type] }}</h2>
+      {% endif %}
+      {% if messages|length > 1 %}
+        <ul class="item-list item-list--messages">
+          {% for message in messages %}
+            <li class="item item--message">{{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p>{{ messages|first }}</p>
+      {% endif %}
+    </div>
+  {% endfor %}
   </div>
-{% endfor %}
+</div>

--- a/wxt_bootstrap.make
+++ b/wxt_bootstrap.make
@@ -5,6 +5,6 @@ api = 2
 
 ; Modules
 
-projects[bootstrap][version] = 3.12
+projects[bootstrap][version] = 3.16
 projects[bootstrap][type] = theme
 projects[bootstrap][subdir] = contrib


### PR DESCRIPTION
## Completed
1. Updated to upstream [drupal/bootstrap 3.16](https://www.drupal.org/project/bootstrap/releases/8.x-3.16). Not updated since 3.12 so figured out which ```.twig``` files to edit with ```git difftool -g --name-only 8.x-3.12 8.x-3.16 | grep "twig"``` and ```git blame```
1. Updated to upstream [wet-boew/wet-boew 4.0.29](http://wet-boew.github.io/wet-boew/docs/versions/v4.0/v4.0.29-en.html)

## Considered the following updates to templates upstream:
1. Evaluate Issue [#3018064 by markcarver, tanasi, glynster: Unable to easily add "dropdown-menu-right" to menus](https://www.drupal.org/node/3018064)
- **Files affected**:
templates/menu/menu--account.html.twig
templates/menu/menu--main.html.twig
templates/menu/menu.html.twig
**Decision**: did not port because dropdown-menu-right not used in wet-boew.

2. Evaluate Issue [#2966175 by pedro_sv, cgmonroe: Pager uses rel="prev" on the first link](https://www.drupal.org/project/bootstrap/issues/2966175)
 - **File affected**:
templates/system/pager.html.twig
 - **Decision**: Ported issue to benefit from SEO optimization noted.
 - **Commit**: 9787b99 

3. Evaluate Issue [#3018412 by markcarver: Add support for JavaScript Message API](https://www.drupal.org/project/bootstrap/issues/3018412)
 - **File affected**:
templates/system/status-messages.html.twig
- **Decision**: Ported issue to add support for feature.
- **Commit**: cb6e6b6