### PR TITLE
Drupal 9 compatibility deprecated twig fix

### DIFF
--- a/templates/facets/facets-summary-facet.html.twig
+++ b/templates/facets/facets-summary-facet.html.twig
@@ -13,7 +13,7 @@
  * - facet_admin_label: The facet administrative label.
  */
 #}
-<span class="source-summary-item source-summary-item-{{ facet_id|replace("_", "-") }}">
+<span class="source-summary-item source-summary-item-{{ facet_id|replace({'_':'-'}) }}">
 {% if items %}
     <h4>{{ label }}</h4>
     <ul>


### PR DESCRIPTION
Drupal 9 compatibility deprecated twig fix.

FYI: @sylus 
You'll probably recognise this syntax change for twig / Drupal 9 symfony 4.x