### PR TITLE
Enable WET-BOEW inline field validation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -836,7 +836,6 @@ html:lang(fr) .cnjnctn-type-or > [class*=cnjnctn-col]:not(:first-child):before {
 }
 
 .select-wrapper {
-  display: inline-block;
   position: relative;
   width: fit-content;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -895,19 +895,6 @@ html:lang(fr) .cnjnctn-type-or > [class*=cnjnctn-col]:not(:first-child):before {
   color: #8a6d3b;
 }
 
-.form-required:after {
-  content: "";
-  background-image: url(../images/required.svg);
-  display: inline-block;
-  line-height: 1;
-  color: #e00;
-  background-size: 7px 7px;
-  width: 7px;
-  vertical-align: super;
-  margin-left: 4px;
-  height: 7px;
-}
-
 .form-item h4.label {
   border: none;
   padding: 0px;

--- a/sass/component/_form.scss
+++ b/sass/component/_form.scss
@@ -71,21 +71,6 @@
   }
 }
 
-// Use CSS for required mark.
-// Inspired from https://www.drupal.org/node/2152217.
-.form-required:after {
-  content:"";
-  background-image: url(../images/required.svg);
-  display: inline-block;
-  line-height:1;
-  color: #e00;
-  background-size:7px 7px;
-  width: 7px;
-  vertical-align: super;
-  margin-left: 4px;
-  height: 7px;
-}
-
 .form-item {
   h4.label {
     border: none;

--- a/sass/component/_form.scss
+++ b/sass/component/_form.scss
@@ -9,7 +9,6 @@
 // around the select element to style it properly.
 // $see http://stackoverflow.com/q/21103542
 .select-wrapper {
-  display: inline-block;
   position: relative;
   width: fit-content;
   .form-inline & {

--- a/templates/input/form-element-label.html.twig
+++ b/templates/input/form-element-label.html.twig
@@ -18,31 +18,35 @@
  * @see template_preprocess_form_element_label()
  */
 #}
+
 {%-
   set classes = [
-    'control-label',
     title_display == 'after' ? 'option',
     title_display == 'invisible' and not (is_checkbox or is_radio) ? 'sr-only',
     required ? 'js-form-required',
     required ? 'form-required',
+    required ? 'required'
   ]
 -%}
 {% if title is not empty and title_display == 'invisible' and (is_checkbox or is_radio) -%}
-  {#
-  Clear but preserve label text as attribute (e.g. for screen readers) for
-  checkboxes/radio buttons when it actually should be invisible.
-  #}
+  {# Make invisible labels for checkboxes/radios to make them screen-reader friendly #}
   {%- set attributes = attributes.setAttribute('title', title) -%}
   {%- set title = null -%}
 {%- endif -%}
+
 {#
 Labels for single checkboxes/radios contain the element itself and thus have
 always to be rendered regardless of whether they have a title or not.
 #}
 {%- if title is not empty or is_checkbox or is_radio -%}
-  <label{{ attributes.addClass(classes) }}>{{ element }}{{ title }}
-    {%- if description -%}
+  <label{{ attributes.addClass(classes) }}>
+    {{ element }}
+    <span class="field-name">{{ title }}</span>
+    {% if required %}
+      <strong class="required" aria-hidden="true">({{ 'required'|t }})</strong>
+    {% endif %}
+    {% if description %}
       <p class="help-block">{{ description }}</p>
-    {%- endif -%}
+    {% endif %}
   </label>
 {%- endif -%}


### PR DESCRIPTION
Remove custom CSS and let wet-boew style the required field label, adjust field label markup to allow proper rendering of inline validation messages