### PR TITLE
fix: #3568044 form-required and js-form-required classes are now redundant to required By: joseph.olstad

### DIFF
--- a/templates/input/form-element-label.html.twig
+++ b/templates/input/form-element-label.html.twig
@@ -23,8 +23,6 @@
   set classes = [
     title_display == 'after' ? 'option',
     title_display == 'invisible' and not (is_checkbox or is_radio) ? 'sr-only',
-    required ? 'js-form-required',
-    required ? 'form-required',
     required and not (is_checkbox or is_radio) ? 'required'
   ]
 -%}


### PR DESCRIPTION
fix: #3568044 form-required and js-form-required classes are now redundant to required By: joseph.olstad